### PR TITLE
Narrowed constraint for DMSFilter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php":  ">=5.3.2",
-        "dms/dms-filter": ">=1.0.2"
+        "dms/dms-filter": "~1.0,>=1.0.2"
     },
 
     "autoload": {


### PR DESCRIPTION
This fixes the issue that the latest version 2.0.0 will be installed when using the current stable version of the bundle.
