### PR TITLE
Support Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,11 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=^3
     - php: 7.0
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.0
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
       env: SYMFONY_VERSION=^3
-    - php: 7.0
-      env: SYMFONY_VERSION=^4
-    - php: 7.0
-      env: SYMFONY_VERSION=dev-master@dev
     - php: 7.1
       env: SYMFONY_VERSION=3.0.*
     - php: 7.1
@@ -46,5 +44,4 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION=dev-master@dev
   allow_failures:
-    - php: 7.2
     - env: SYMFONY_VERSION=dev-master@dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,30 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 5.6
       env: SYMFONY_VERSION=^3
+    - php: 7.0
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.0
+      env: SYMFONY_VERSION=^3
+    - php: 7.0
+      env: SYMFONY_VERSION=^4
+    - php: 7.0
+      env: SYMFONY_VERSION=dev-master@dev
     - php: 7.1
       env: SYMFONY_VERSION=3.0.*
     - php: 7.1
       env: SYMFONY_VERSION=^3
     - php: 7.1
+      env: SYMFONY_VERSION=^4
+    - php: 7.1
+      env: SYMFONY_VERSION=dev-master@dev
+    - php: 7.2
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.2
+      env: SYMFONY_VERSION=^3
+    - php: 7.2
+      env: SYMFONY_VERSION=^4
+    - php: 7.2
       env: SYMFONY_VERSION=dev-master@dev
   allow_failures:
+    - php: 7.2
     - env: SYMFONY_VERSION=dev-master@dev

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php":  "^5.6|^7",
         "dms/dms-filter": "^2.0 | ^3.0",
-        "symfony/symfony": "^2.8 | ^3"
+        "symfony/symfony": "^2.8 | ^3.0 | ^4.0"
     },
 
     "require-dev": {

--- a/src/DMS/Bundle/FilterBundle/Resources/config/services.yml
+++ b/src/DMS/Bundle/FilterBundle/Resources/config/services.yml
@@ -7,11 +7,13 @@ services:
 
     dms.filter:
         class: DMS\Bundle\FilterBundle\Service\Filter
+        public: true
         arguments:
             - '@dms.filter.inner.filter'
 
     dms.filter.type_extension:
         class: DMS\Bundle\FilterBundle\Form\Type\FormTypeFilterExtension
+        public: true
         arguments:
             - '@dms.filter'
             - '%dms_filter.auto_filter_forms%'
@@ -25,6 +27,7 @@ services:
 
     dms.filter.mapping.loader:
         class: '%dms.filter.mapping.loader.class%'
+        public: true
         arguments:
             - '@annotation_reader'
 
@@ -41,5 +44,6 @@ services:
 
     dms.filter.container_filter:
         class: DMS\Bundle\FilterBundle\Filter\ContainerFilter
+        public: true
         calls:
             - [setContainer, ['@service_container']]


### PR DESCRIPTION
- Update composer dependency to allow Symfony 4
- Migrate services to the changed visibility default in Symfony 4
- Run Travis against PHP 7.0 and PHP 7.2