### PR TITLE
Update Service Rule to accept custom options

### DIFF
--- a/src/DMS/Bundle/FilterBundle/Filter/ContainerFilter.php
+++ b/src/DMS/Bundle/FilterBundle/Filter/ContainerFilter.php
@@ -60,6 +60,6 @@ class ContainerFilter extends BaseFilter implements ContainerAwareInterface
 
         $method = $rule->method;
 
-        return $service->$method($value);
+        return $service->$method($value, $rule->options);
     }
 }

--- a/src/DMS/Bundle/FilterBundle/Rule/Service.php
+++ b/src/DMS/Bundle/FilterBundle/Rule/Service.php
@@ -18,6 +18,11 @@ class Service extends Rule
     public string $method;
 
     /**
+     * @var mixed
+     */
+    public $options;
+
+    /**
      * {@inheritdoc}
      */
     public function getRequiredOptions(): array


### PR DESCRIPTION
This PR allows the addition of a third optional parameter to the service rule declaration.

```php
@SfFilter\Service(service="services.custom_filter", method="customMethode", options={"class":"App\Entity\User"})
 // OR
@SfFilter\Service(service="services.custom_filter", method="filterEntity", options="some string value")
```

For my case i can use it like this : 

```php
<?php

namespace App\Entity;

use DMS\Filter\Rules as Filter;
use DMS\Bundle\FilterBundle\Rule as SfFilter;

class Post
{
	/**
     * @var App\Entity\User
     *
     * @ORM\ManyToOne(targetEntity="App\Entity\User")
     *
     * @SfFilter\Service(service="services.custom_filter", method="filterEntity", options={"class":"App\Entity\User"})
     */
    public $user;
}
```